### PR TITLE
fix file name to .env to fixed windows not read it

### DIFF
--- a/app/configs.py
+++ b/app/configs.py
@@ -4,4 +4,7 @@ from pydantic_settings import BaseSettings
 class Configs(BaseSettings):
     AIFORTHAI_APIKEY: str
     LINE_CHANNEL_ACCESS_TOKEN: str
-    LINE_CHANNEL_SECRET:str      
+    LINE_CHANNEL_SECRET: str
+
+    class Config:
+        env_file = ".env"


### PR DESCRIPTION
แก้ปัญหา Windows ไม่อ่าน .env 